### PR TITLE
Fix routing imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "clsx": "^2.1.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "react-router": "^7.6.2"
+        "react-router-dom": "^7.6.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
@@ -2646,9 +2646,9 @@
         "react": "^19.1.0"
       }
     },
-    "node_modules/react-router": {
+    "node_modules/react-router-dom": {
       "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.2.tgz",
       "integrity": "sha512-U7Nv3y+bMimgWjhlT5CRdzHPu2/KVmqPwKUCChW8en5P3znxUqwlYFlbmyj8Rgp1SF6zs5X4+77kBVknkg6a0w==",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "clsx": "^2.1.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router": "^7.6.2"
+    "react-router-dom": "^7.6.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/src/Layout.tsx
+++ b/src/Layout.tsx
@@ -1,6 +1,6 @@
 import './Home.module.css'
 import Header from '@/components/Header/Header.tsx'
-import { Outlet } from 'react-router'
+import { Outlet } from 'react-router-dom'
 import Container from '@/components/Container/Container.tsx'
 import Footer from '@/components/Footer/Footer.tsx'
 

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,7 +1,7 @@
 import Container from '@/components/Container/Container.tsx'
 import styles from './Footer.module.css'
 import logo from '@/assets/logo-white.svg'
-import { Link } from 'react-router'
+import { Link } from 'react-router-dom'
 
 const Footer = () => {
   return (

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -2,7 +2,7 @@ import styles from './Header.module.css'
 import logo from '@/assets/logo.svg'
 
 import clsx from 'clsx'
-import { Link, NavLink } from 'react-router'
+import { Link, NavLink } from 'react-router-dom'
 import Container from '@/components/Container/Container.tsx'
 
 const Header = () => {

--- a/src/components/HousingCard/HousingCard.tsx
+++ b/src/components/HousingCard/HousingCard.tsx
@@ -1,6 +1,6 @@
 import styles from './HousingCard.module.css'
 import type { Logement } from '@/types/global.type.ts'
-import { Link } from 'react-router'
+import { Link } from 'react-router-dom'
 
 interface HousingCardProps {
   logement: Logement

--- a/src/loaders/logement.loader.ts
+++ b/src/loaders/logement.loader.ts
@@ -1,4 +1,4 @@
-import type { LoaderFunction } from 'react-router'
+import type { LoaderFunction } from 'react-router-dom'
 import type { Logement } from '@/types/global.type'
 
 export const logementLoader: LoaderFunction = async ({ params }) => {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,7 @@
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import Layout from './Layout.tsx'
-import { createBrowserRouter, Navigate, RouterProvider } from 'react-router'
+import { createBrowserRouter, Navigate, RouterProvider } from 'react-router-dom'
 import Home from '@/Home.tsx'
 import LogementDetail from '@/pages/LogementDetail.tsx'
 import NotFound from '@/pages/NotFound.tsx'

--- a/src/pages/LogementDetail.tsx
+++ b/src/pages/LogementDetail.tsx
@@ -1,5 +1,5 @@
 import styles from './LogementDetail.module.css'
-import { Link, useLoaderData, useLocation } from 'react-router'
+import { Link, useLoaderData, useLocation } from 'react-router-dom'
 
 import type { Logement } from '@/types/global.type'
 import {


### PR DESCRIPTION
## Summary
- use `react-router-dom` instead of `react-router`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run format` *(fails: Unknown file extension ".mts" for prettier config)*
- `npm run build` *(fails: missing dependencies due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68533b50d9b48332843a7e7374d909b7