### PR TITLE
Add responsive breakpoints and rem units

### DIFF
--- a/src/components/Button/Button.module.css
+++ b/src/components/Button/Button.module.css
@@ -1,13 +1,13 @@
 .btn {
-    border-radius: 8px;
+    border-radius: 0.5rem;
     background: #222;
     display: flex;
-    padding: 12px 19px;
+    padding: 0.75rem 1.1875rem;
     justify-content: center;
     align-items: center;
-    gap: 10px;
+    gap: 0.625rem;
     color: #D9D9D9;
-    font-size: clamp(12px, 1.4vw, 14px);
+    font-size: clamp(0.75rem, 1.4vw, 0.875rem);
     font-weight: 500;
     line-height: 142.6%;
     cursor: pointer;
@@ -16,8 +16,8 @@
 
 
     svg {
-        width: 16px;
-        height: 16px;
+        width: 1rem;
+        height: 1rem;
         transition: transform 0.2s ease;
         flex-shrink: 0;
         fill: currentColor;
@@ -30,13 +30,13 @@
 
     }
 
-    @media (max-width: 480px) {
-        padding: 10px 14px;
-        font-size: 12px;
+    @media (max-width: 30rem) {
+        padding: 0.625rem 0.875rem;
+        font-size: 0.75rem;
 
         svg {
-            width: 14px;
-            height: 14px;
+            width: 0.875rem;
+            height: 0.875rem;
         }
     }
 }
@@ -51,3 +51,4 @@
 
     }
 }
+

--- a/src/components/Container/Container.module.css
+++ b/src/components/Container/Container.module.css
@@ -6,14 +6,21 @@
 
 /* The actual container inside a fullWidth wrapper */
 .inner {
-    max-width: 1440px;
+    max-width: 90rem;
     margin: 0 auto;
     width: 100%;
 }
 
 
 .container {
-    max-width: 1440px;
+    max-width: 90rem;
     margin: 0 auto;
     width: 100%;
+}
+
+@media (max-width: 64rem) {
+    .inner,
+    .container {
+        padding: 0 1rem;
+    }
 }

--- a/src/components/Footer/Footer.module.css
+++ b/src/components/Footer/Footer.module.css
@@ -1,23 +1,23 @@
 .footer {
     display: flex;
-    padding: 24px 40px;
+    padding: 1.5rem 2.5rem;
     justify-content: space-between;
     align-items: center;
-    border-radius: 16px 16px 0 0;
+    border-radius: 1rem 1rem 0 0;
     background: #222;
 }
 
-@media (max-width: 1440px) {
+@media (max-width: 90rem) {
     .footer {
-        border-radius: 16px;
-        margin: 16px;
+        border-radius: 1rem;
+        margin: 1rem;
         width: unset;
     }
 }
 
 
 .logo {
-    max-height: 40px;
+    max-height: 2.5rem;
     display: block;
 }
 

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -1,14 +1,14 @@
 .root {
-    padding: 32px 0;
+    padding: 2rem 0;
     border-bottom: 1px solid #ebebeb;
     background-color: #fcfcfc;
     box-shadow: 0 2px 12px rgba(0, 0, 0, 0.01);
 }
 
 
-@media (max-width: 1440px) {
+@media (max-width: 90rem) {
     .root {
-        padding: 32px 40px
+        padding: 2rem 2.5rem
     }
 }
 
@@ -24,12 +24,12 @@
 .left {
     display: flex;
     align-items: center;
-    gap: 96px;
+    gap: 6rem;
 }
 
 .nav {
     display: flex;
-    gap: 48px;
+    gap: 3rem;
     margin: 0;
     padding: 0;
     list-style: none;
@@ -67,13 +67,13 @@
 
 .right {
     display: flex;
-    gap: 16px;
+    gap: 1rem;
     align-items: center;
 }
 
 
 .logo {
-    max-height: 40px;
+    max-height: 2.5rem;
     display: block;
 }
 

--- a/src/components/HousingCard/HousingCard.module.css
+++ b/src/components/HousingCard/HousingCard.module.css
@@ -3,7 +3,7 @@
     flex-direction: column;
     height: 100%;
     cursor: pointer;
-    gap: 12px;
+    gap: 0.75rem;
     overflow: visible;
     transition: 250ms ease-in-out;
 }
@@ -15,7 +15,7 @@
 
 .card:focus-visible {
     outline: none;
-    gap: 16px;
+    gap: 1rem;
 }
 
 .card:hover h4, .card:focus-visible h4 {
@@ -28,7 +28,7 @@
 
 
 .cover {
-    border-radius: 8px;
+    border-radius: 0.5rem;
     border: 1px solid rgba(255, 96, 96, 0.25);
     aspect-ratio: 4 / 4;
     object-fit: cover;
@@ -46,7 +46,7 @@
 
 .title {
     color: #222;
-    font-size: 12px;
+    font-size: 0.75rem;
     font-weight: 500;
     line-height: 1.4;
     transition: 180ms ease-in-out;
@@ -54,7 +54,7 @@
 
 .location {
     color: #666;
-    font-size: 12px;
+    font-size: 0.75rem;
     font-weight: 500;
     line-height: 1.4;
     transition: 80ms ease-in-out;

--- a/src/index.css
+++ b/src/index.css
@@ -7,7 +7,7 @@
 html {
     line-height: 1.15;
     -webkit-text-size-adjust: 100%;
-    font-size: 16px;
+    font-size: 100%;
     font-family: "Montserrat", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
     Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue",
     sans-serif;
@@ -94,12 +94,18 @@ p, h1, h2, h3, h4, h5, h6 {
 
 
 .main {
-    padding: 40px;
+    padding: 2.5rem;
     display: flex;
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    gap: 10px;
+    gap: 0.625rem;
     flex: 1 0 0;
-    align-self: stretch;;
+    align-self: stretch;
+}
+
+@media (max-width: 37.5rem) {
+    .main {
+        padding: 1.5rem 1rem;
+    }
 }

--- a/src/pages/Home/Home.module.css
+++ b/src/pages/Home/Home.module.css
@@ -3,18 +3,18 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    padding: 48px 40px;
+    padding: 3rem 2.5rem;
     align-items: flex-start;
-    gap: 48px;
+    gap: 3rem;
     flex: 1 0 0;
     align-self: stretch;
-    border-radius: 16px;
+    border-radius: 1rem;
     background: #EDEBE9;
 }
 
 .sectionHeader {
     display: flex;
-    gap: 64px;
+    gap: 4rem;
     margin: 0;
     align-self: stretch;
     grid-template-rows: repeat(1, minmax(0, 1fr));
@@ -36,19 +36,19 @@
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    gap: 16px;
+    gap: 1rem;
     align-self: stretch;
 }
 
 .iconList {
     display: flex;
     align-items: center;
-    gap: 16px;
+    gap: 1rem;
 }
 
 .subtitle {
     color: #222;
-    font-size: 16px;
+    font-size: 1rem;
     font-style: normal;
     font-weight: 500;
     line-height: 140%; /* 22.4px */
@@ -56,8 +56,8 @@
 
 .icon {
     display: flex;
-    width: 40px;
-    height: 40px;
+    width: 2.5rem;
+    height: 2.5rem;
     flex-direction: column;
     justify-content: center;
     align-items: center;
@@ -66,7 +66,7 @@
     background: #FFF;
 
     svg {
-        height: 16px;
+        height: 1rem;
         width: auto;
         flex-shrink: 0;
 
@@ -82,24 +82,24 @@
     flex-direction: column;
     justify-content: center;
     align-items: flex-start;
-    gap: 16px;
+    gap: 1rem;
     flex: 1 0 0;
     align-self: stretch;
 
     h3 {
         color: #222;
-        font-size: 24px;
+        font-size: 1.5rem;
         margin: 0;
         font-weight: 500;
         line-height: 142.6%;
-        padding-left: 16px;
+        padding-left: 1rem;
         position: relative;
 
         &:before {
             content: '';
             position: absolute;
-            width: 4px;
-            height: 24px;
+            width: 0.25rem;
+            height: 1.5rem;
             background-color: #FF6060;
             left: 0;
             top: 50%;
@@ -110,10 +110,23 @@
 
 .grid {
     display: grid;
-    row-gap: 10px;
-    column-gap: 16px;
+    row-gap: 0.625rem;
+    column-gap: 1rem;
     flex: 1 0 0;
     align-self: stretch;
     grid-template-rows: repeat(2, minmax(0, 1fr));
     grid-template-columns: repeat(5, minmax(0, 1fr));
+}
+
+@media (max-width: 56.25rem) {
+    .grid {
+        grid-template-columns: repeat(2, 1fr);
+        grid-template-rows: repeat(5, 1fr);
+    }
+}
+
+@media (max-width: 37.5rem) {
+    .grid {
+        grid-template-columns: 1fr;
+    }
 }

--- a/src/pages/LogementDetail/LogementDetail.module.css
+++ b/src/pages/LogementDetail/LogementDetail.module.css
@@ -1,8 +1,8 @@
 .detailPage {
     display: grid;
-    gap: 24px;
-    padding: 40px;
-    grid-template-columns: minmax(280px, 500px) 1fr;
+    gap: 1.5rem;
+    padding: 2.5rem;
+    grid-template-columns: minmax(17.5rem, 31.25rem) 1fr;
     grid-template-rows: auto;
     grid-template-areas:
     "gallery content";
@@ -135,10 +135,10 @@
 
 .hostSection {
     display: flex;
-    padding: 32px 16px;
+    padding: 2rem 1rem;
     flex-direction: column;
     align-items: flex-start;
-    gap: 16px;
+    gap: 1rem;
     align-self: stretch;
     border-radius: 14px;
     background: #EDEBE9;
@@ -242,12 +242,12 @@
 
 .content {
     display: flex;
-    padding: 32px;
+    padding: 2rem;
     flex-direction: column;
-    gap: 32px;
+    gap: 2rem;
     flex: 1 0 0;
     align-self: stretch;
-    border-radius: 16px;
+    border-radius: 1rem;
     background: linear-gradient(0deg, #EDEBE9 0%, #EDEBE9 100%), #FFF;
     align-items: flex-start;
 
@@ -455,3 +455,4 @@
         }
     }
 }
+


### PR DESCRIPTION
## Summary
- refactor container width and add mobile padding
- switch global font size and page padding to rem
- update footer, header and button styling
- convert housing card and home page spacing to rem units
- adjust logement detail layout with rem values and spacing

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6854151ba4c08332aee08e8cf135de6f