### PR TITLE
Refactor logement data fetching

### DIFF
--- a/src/api/logements.ts
+++ b/src/api/logements.ts
@@ -1,0 +1,22 @@
+import type { Logement } from '@/types/global.type'
+
+let logementsCache: Logement[] | null = null
+
+export const getLogements = async (): Promise<Logement[]> => {
+  if (logementsCache) return logementsCache
+
+  const res = await fetch('/data/logements.json')
+  if (!res.ok) {
+    throw new Error('Failed to fetch logements')
+  }
+  const data: Logement[] = await res.json()
+  logementsCache = data
+  return data
+}
+
+export const getLogementById = async (
+  id: string
+): Promise<Logement | undefined> => {
+  const logements = await getLogements()
+  return logements.find((item) => item.id === id)
+}

--- a/src/loaders/logement.loader.ts
+++ b/src/loaders/logement.loader.ts
@@ -1,14 +1,12 @@
 import type { LoaderFunction } from 'react-router-dom'
 import type { Logement } from '@/types/global.type'
+import { getLogementById } from '@/api/logements.ts'
 
 export const logementLoader: LoaderFunction = async ({ params }) => {
   const id = params.id
   if (!id) throw new Response('Missing logement ID', { status: 400 })
 
-  const res = await fetch('/data/logements.json')
-  const data: Logement[] = await res.json()
-
-  const logement = data.find((item) => item.id === id)
+  const logement = await getLogementById(id)
 
   if (!logement) {
     throw new Response('LogementDetail not found', { status: 404 })

--- a/src/pages/Home/Home.module.css
+++ b/src/pages/Home/Home.module.css
@@ -12,6 +12,11 @@
     background: #EDEBE9;
 }
 
+.error {
+    color: #c00;
+    padding: 8px 0;
+}
+
 .sectionHeader {
     display: flex;
     gap: 64px;

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -3,16 +3,18 @@ import { CheckIcon, GlobeIcon, HomeIcon } from '@radix-ui/react-icons'
 import { useEffect, useState } from 'react'
 import type { Logement } from '@/types/global.type.ts'
 import HousingCard from '@/components/HousingCard/HousingCard.tsx'
+import { getLogements } from '@/api/logements.ts'
 
 const Home = () => {
   const [logements, setLogements] = useState<Logement[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
-    // Fetch logements from the JSON file
-    fetch('/data/logements.json')
-      .then((response) => response.json())
+    getLogements()
       .then((data) => setLogements(data))
-      .catch((error) => console.error('Failed to fetch logements:', error))
+      .catch(() => setError('Failed to fetch logements'))
+      .finally(() => setLoading(false))
   }, [])
 
   return (
@@ -41,8 +43,11 @@ const Home = () => {
       </div>
       <div className={styles.content}>
         <h3>Logements</h3>
+        {loading && <p>Chargement...</p>}
+        {error && <p className={styles.error}>{error}</p>}
         <div className={styles.grid}>
-          {logements.length > 0 &&
+          {!loading &&
+            !error &&
             logements
               .slice(0, 10)
               .map((logement) => <HousingCard key={logement.id} logement={logement} />)}

--- a/src/pages/LogementDetail/LogementDetail.tsx
+++ b/src/pages/LogementDetail/LogementDetail.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { Link, useLoaderData, useLocation } from 'react-router-dom'
+import { Link, useLoaderData, useLocation, useNavigation } from 'react-router-dom'
 import styles from './LogementDetail.module.css'
 
 import type { Logement } from '@/types/global.type'
@@ -12,6 +12,7 @@ import {
 import Button from '@/components/Button/Button.tsx'
 
 const LogementDetail = () => {
+  const navigation = useNavigation()
   const { state } = useLocation() as { state?: { logement?: Logement } }
   const loaderLogement = useLoaderData() as Logement
   const logement = state?.logement ?? loaderLogement
@@ -23,6 +24,10 @@ const LogementDetail = () => {
       logement.equipments.slice(i * chunkSize, (i + 1) * chunkSize)
     )
   }, [logement.equipments])
+
+  if (navigation.state === 'loading') {
+    return <p>Chargement du logement...</p>
+  }
 
   return (
     <div className={styles.detailPage}>


### PR DESCRIPTION
## Summary
- centralize logement fetching logic with caching
- show loading and error messages on the Home page
- show navigation loading state on the Logement detail page
- reuse cached data inside the logement route loader

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run format` *(fails: Unknown file extension ".mts" for prettier config)*

------
https://chatgpt.com/codex/tasks/task_e_685422b64f9083329f9920932371a495